### PR TITLE
Fix/ Eslint webpack dev configuration

### DIFF
--- a/packages/monorepo-scripts/config/webpack.config.dev.js
+++ b/packages/monorepo-scripts/config/webpack.config.dev.js
@@ -200,7 +200,8 @@ module.exports = {
           {
             options: {
               formatter: require.resolve('react-dev-utils/eslintFormatter'),
-              eslintPath: require.resolve('eslint')
+              eslintPath: require.resolve('eslint'),
+              emitWarning: true
             },
             loader: require.resolve('eslint-loader')
           }


### PR DESCRIPTION
On development, the Eslint Webpack loader was configured in a way so that Eslint warnings and errors would prevent the build from recompiling. This disables that, allowing us to run our linter on pre-commit.